### PR TITLE
Improve method of reading status and support "hit-rule" entry from AFD and baseline testbed

### DIFF
--- a/ftw_compatible_tool/web_interface.py
+++ b/ftw_compatible_tool/web_interface.py
@@ -92,7 +92,7 @@ def execute():
             response = HTTPResponse(FakeSocket(
                 raw_response.encode('ascii', 'ignore')))
             response.begin()
-            payload["result"] = response.status
+            payload["result"] = str(response.status)
             if response.getheader("x-fd-int-waf-rule-hits"):  # parse AFD's hitrule
                 payload["hitRule"] = response.getheader(
                     "x-fd-int-waf-rule-hits")

--- a/ftw_compatible_tool/web_interface.py
+++ b/ftw_compatible_tool/web_interface.py
@@ -92,14 +92,14 @@ def execute():
             response = HTTPResponse(FakeSocket(
                 raw_response.encode('ascii', 'ignore')))
             response.begin()
-            payload["status"] = response.status
+            payload["result"] = response.status
             if response.getheader("x-fd-int-waf-rule-hits"):  # parse AFD's hitrule
                 payload["hitRule"] = response.getheader(
                     "x-fd-int-waf-rule-hits")
             elif response.status == 302 and response.getheader("Location"):
                 res = parse_qs(urlparse(response.getheader("Location")).query)
                 payload["hitRule"] = res["modsec_ruleid"][0].replace('-', ',')
-                payload["status"] = res["status"][0]
+                payload["result"] = res["status"][0]
         json_result.append(payload)
 
     # clean up

--- a/ftw_compatible_tool/web_interface.py
+++ b/ftw_compatible_tool/web_interface.py
@@ -98,7 +98,9 @@ def execute():
                     "x-fd-int-waf-rule-hits")
             elif response.status == 302 and response.getheader("Location"):
                 res = parse_qs(urlparse(response.getheader("Location")).query)
-                payload["hitRule"] = res["modsec_ruleid"][0].replace('-', ',')
+                hit_rules = ','.join(reversed(filter(None,
+                                                     res["modsec_ruleid"][0].split("-"))))
+                payload["hitRule"] = hit_rules
                 payload["result"] = res["status"][0]
         json_result.append(payload)
 

--- a/ftw_compatible_tool/web_interface.py
+++ b/ftw_compatible_tool/web_interface.py
@@ -9,9 +9,21 @@ from flask import Flask, request, jsonify
 from werkzeug.utils import secure_filename
 import sqlite3
 
+from httplib import HTTPResponse
+from io import BytesIO
+from urlparse import urlparse, parse_qs
+
 
 app = Flask(__name__)
 app.config['UPLOAD_PATH'] = '/tmp'
+
+
+class FakeSocket():
+    def __init__(self, response_bytes):
+        self._file = BytesIO(response_bytes)
+
+    def makefile(self, *args, **kwargs):
+        return self._file
 
 
 @app.route('/', methods=['GET'])
@@ -67,9 +79,6 @@ def execute():
         shutil.rmtree(yaml_path)
         return 'Failed to retrieve result files', 500
 
-    # regex to match status code in raw response
-    p = re.compile('HTTP\/\d\.\d (\d{3})')
-
     # preparing json return
     json_result = []
     conn = sqlite3.connect(result_name)
@@ -79,7 +88,18 @@ def execute():
         test_title, raw_response = row
         payload = {}
         payload['title'] = test_title
-        payload['result'] = p.match(raw_response).groups()[0]
+        if raw_response:  # parse http resposne
+            response = HTTPResponse(FakeSocket(
+                raw_response.encode('ascii', 'ignore')))
+            response.begin()
+            payload["status"] = response.status
+            if response.getheader("x-fd-int-waf-rule-hits"):  # parse AFD's hitrule
+                payload["hitRule"] = response.getheader(
+                    "x-fd-int-waf-rule-hits")
+            elif response.status == 302 and response.getheader("Location"):
+                res = parse_qs(urlparse(response.getheader("Location")).query)
+                payload["hitRule"] = res["modsec_ruleid"][0].replace('-', ',')
+                payload["status"] = res["status"][0]
         json_result.append(payload)
 
     # clean up


### PR DESCRIPTION
This PR includes
* improvement in reading HTTP raw response. We now parse the raw response as a response struct instead of extracting string from it with Regexp.
* support parsing the "hit-rule" entry from ADF and our baseline testbed